### PR TITLE
fix-pdf-printing-error

### DIFF
--- a/ceylon.css
+++ b/ceylon.css
@@ -489,6 +489,27 @@ h6::before {
   height: calc(100% - 4px);
 }
 
+@media print {
+  h1::before {
+    height: 33.63px;
+  }
+  h2::before {
+    height: 30.64px;
+  }
+  h3::before {
+    height: 28.92px;
+  }
+  h4::before {
+    height: 22.66px;
+  }
+  h5::before {
+    height: 21.39px;
+  }
+  h6::before {
+    height: 22.8px;
+  }
+}
+
 h1:hover::before,
 h1.md-focus::before {
   content: 'H1';


### PR DESCRIPTION
Your fix to my issue #2 does not work well.

My OS is `Windows 23H2`. Typora version is `1.9.5`. 

The root cause is that when outputing to a PDF, the `100%` of `calc(100% - 4px)` is not the height of `h1/h2/h3/h4/h5/h6 box`. And I don't know why. Maybe some bugs inside Typora.

So, I use `@media` to give element `:before` a fixed height.

It works well on my OS and Typora.